### PR TITLE
Alternative comment syntax :: to end-of-line

### DIFF
--- a/lstlangmizar.sty
+++ b/lstlangmizar.sty
@@ -3,6 +3,9 @@
 %% Mizar definition (c) 2012 Josef Urban
 %%                           <Josef.Urban@gmail.com>
 %%
+%% minor enhancements (c) 2013 Christoph Lange
+%%                             <math.semantic.web@gmail.com>
+%%
 \lstdefinelanguage{Mizar}%
 {morekeywords={schemes,constructors,definitions,theorems,vocabularies,requirements,registrations,
 notations,theorem,scheme,definition,registration,notation,axiom,proof,now,end,hereby,case,suppose,
@@ -15,6 +18,7 @@ associativity,commutativity,connectedness,irreflexivity,reduce,reducibility,refl
 sethood,uniqueness,transitivity,idempotence,asymmetry,projectivity,involutiveness
 	},% 
    sensitive, %
+   morecomment=[l]{::},%
    morecomment=[n]{(:}{:)},%
    morestring=[d]",%
    literate={=>}{{$\Rightarrow$}}1 {>->}{{$\rightarrowtail$}}2{->}{{$\to$}}1


### PR DESCRIPTION
@JUrban, I forked your repository to add an alternative comment syntax. This is my first pull request; I'm not exactly sure how this will work.
