### PR TITLE
Bugfixes for Emacs 28, 29

### DIFF
--- a/mizar.el
+++ b/mizar.el
@@ -2093,7 +2093,8 @@ If TABLE is not given, get it with `mizar-get-errors'."
 		   local-map-kword mizar-momm-err-map)))
   (if atab
       (save-excursion
-	(setq lline (goto-line (caar atab)))
+    (setq lline (progn (goto-char (point-min))
+                       (forward-line (1- (caar atab)))))
 	(if (or (and (eq mizar-emacs 'xemacs) (not lline))
 		(and (not (eq mizar-emacs 'xemacs)) (< 0 lline)))
 	    (error "Main buffer and the error file do not agree, run verifier!"))

--- a/mizar.el
+++ b/mizar.el
@@ -5624,7 +5624,9 @@ This is a flamewar-resolving hack."
 	  (if bold (make-face-bold facename))
 	  (if ital (make-face-italic facename))
 	  (if bold (make-face-bold facename))
-	  (set-face-underline-p facename under)
+      (if (>= emacs-major-version 24)
+	      (set-face-underline facename under)
+	    (set-face-underline-p facename under))
 	  ;; This is needed under Emacs 20 for some reason.
 	  (set facename facename)
 	  ))


### PR DESCRIPTION
The two "major" changes:

1. Emacs 28 changed the semantics of `goto-line`, which should have always been the "goto char, then next line" setup anyways.
2. Emacs 29 removed `set-face-underline-p` (which has been marked deprecated since Emacs 24). It has been replaced by `set-face-underline` for the past few major releases, so I just swapped that in.

Without the first change (to `goto-line`), it'd be impossible to run the verifier. Without the second change, it'd be impossible to work _at all_ in Emacs 29.